### PR TITLE
[REGION_EXTRACTIONS] fix doc + .env.template: remove outdated references to regions

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,8 +4,8 @@ TARGET=dev
 # Is the API running in a Docker container?
 DOCKER=False
 
-# apps to be imported to the API (dticlustering / watermarks / similarity / regions / vectorization / search)
-INSTALLED_APPS=similarity,regions
+# apps to be imported to the API (dticlustering / watermarks / similarity / region_extraction / vectorization / search)
+INSTALLED_APPS=similarity,region_extraction
 
 # Exposed port for the API
 API_PORT=5001
@@ -29,7 +29,7 @@ API_DATA_FOLDER=data/
 #######################
 
 #######################
-#       REGIONS       #
+#  REGION_EXTRACTION  #
 #######################
 
 # folder path for yolo tmp files keep /data/yolotmp for Docker, data/yolotmp for dev

--- a/app/region_extraction/routes.py
+++ b/app/region_extraction/routes.py
@@ -3,7 +3,7 @@ Routes for the regions extraction API.
 
 Routes:
 
-- POST ``/regions/start``:
+- POST ``/region_extraction/start``:
     Starts the regions extraction process for a dataset.
 
     - Parameters:


### PR DESCRIPTION
in the API, the `regions` module is now `region_extraction` => remove outdated references to regions.