### PR TITLE
Izinstall

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -36,6 +36,8 @@ CUDA_HOME=
 # ----------------------- advanced (defaults are fine) -----------------------
 
 DRAMATIQ_PROM_PORT=9192
+# a Dockerized AIKON-api should always use `localhost`: its Dockerfile installs a local redis-server
+REDIS_HOST=localhost
 # Redis database index used by dramatiq (use a different index than the front's celery, which uses 0)
 REDIS_DB_INDEX=1
 YOLO_CONFIG_DIR=

--- a/install.py
+++ b/install.py
@@ -99,7 +99,7 @@ def resolve(mode: str, root_env: Path, use_defaults: bool) -> dict:
             and (
                 # key is not expected in `root`
                 key not in ROOT_MAP.values()
-                # or key is present in `root` but has no value
+                # key has no value in `root` (useful for INSTALLED_APPS in AIKON-demo)
                 or root.get(root_key) is None
             )
         ):
@@ -123,12 +123,13 @@ def resolve(mode: str, root_env: Path, use_defaults: bool) -> dict:
     v["YOLO_CONFIG_DIR"] = v["YOLO_CONFIG_DIR"] or str(
         Path(v["API_DATA_FOLDER"]) / "yolotmp"
     )
-    # TODO verify prod value -> should be localhost
-    v["REDIS_HOST"] = (
-        "host.docker.internal" if docker and not root
-        else "redis" if docker
-        else "localhost"
-    )
+    # redis is only dockerized in AIKON-API if the api is 
+    # bundled with a Dockerized AIKON instance: in that case, it 
+    # uses AIKON-front's Redis. otherwise 
+    # v["REDIS_HOST"] = (
+    #     else "redis" if docker and root
+    #     else "localhost"
+    # )
     if docker:
         v["REDIS_PORT"] = "6379"
     if root:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from api!")
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
REDIS_HOST is always localhost in AIKON-api.

in cases some cases, a standalone dockerized redis instance could be used (when an AIKON frontend is dockerized on the same host as the API). in this case, REDIS_HOST could be `host.docker.internal`. 

however, in any case, in AIKON-api's Dockerfile, a redis-server is installed, so this can be used regardless of the configuration => set REDIS_HOST to localhost always 